### PR TITLE
[Bug] Fix two page select dropdowns are not sync in value within same page.

### DIFF
--- a/src/Thread/Thread.js
+++ b/src/Thread/Thread.js
@@ -151,7 +151,7 @@ class Thread extends React.PureComponent {
           { nextPage }
           <b className="Thread-spaceFill"/>
           <div className="Thread-rightAbs">
-            <Dropdown inline scrolling text="㨂頁數" options={ pagesOptions } onChange={ handlePageChange }/>
+            <Dropdown inline scrolling text="㨂頁數" options={ pagesOptions } onChange={ handlePageChange } value={page}/>
           </div>
         </div>
       )


### PR DESCRIPTION
**How to reproduce:**
1. View a topic with more than one pages.
2. Select page other than 1 in the top page select dropdown.
3. Reload finish.
4. Open bottom page select dropdown. It is still displaying 1 instead of the current page.

**Problem:**
From previous example,
1. Select page 2 in the top page select dropdown.
2. Redirected to page 2.
3. Open bottom page select dropdown. Do not select other page.(ie, Close the popup instantly)
4. The app will redirect user to page 1. But this action should not redirect user to the old page.

**Fix:**
Set current page value to both dropdown menu.