### PR TITLE
Prevent scrolling in the main page while drawer is opened

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -66,6 +66,15 @@ class App extends Component {
     const toggleDrawer = e => {
       e.preventDefault()
       this.setState({ drawerOpen: !this.state.drawerOpen })
+      toggleOverflow()
+    }
+    const toggleOverflow = () => {
+      // Prevent scrolling in the main page while drawer is opened
+      if (this.state.drawerOpen) {
+        document.body.style.overflow = 'visible'
+      } else {
+        document.body.style.overflow = 'hidden'
+      }
     }
     const toggleDarkMode = e => {
       e.preventDefault()


### PR DESCRIPTION
Currently, users are able to scroll through the main page despite the opened drawer. Also, when users finish scrolling the drawer and attempt to continue scrolling down, it will start scrolling the main page