### PR TITLE
Page dropdown bug

### DIFF
--- a/src/Category/Category.css
+++ b/src/Category/Category.css
@@ -13,6 +13,9 @@
 .App.light .Category-row:not(:last-child) {
   border-bottom: 1px solid #aaa;
 }
+.Category-row .active {
+  font-weight: normal !important;
+}
 .Category-row > small {
   color: #bdbdbd;
   display: block;

--- a/src/Category/Category.js
+++ b/src/Category/Category.js
@@ -87,7 +87,10 @@ class Category extends React.PureComponent {
         const pagesOptions = new Array(pages).fill().map((_, i) => {
           return { text: `第 ${ i + 1 } 頁`, value: i + 1 }
         })
-        const handlePageChange = (e, item) => browserHistory.push(`/thread/${ c.thread_id }/page/${ item.value }`)
+        const handlePageChange = (e, item) => {
+          if (!Array.isArray(e._dispatchInstances)) return;
+          browserHistory.push(`/thread/${ c.thread_id }/page/${ item.value }`)
+        }
         const color = c.user.level === '999' ? '#FF9800' : (c.user.gender === 'M' ? '#7986CB' : '#F06292')
         return (
           <div key={ `${ c.thread_id }|${ c.last_reply_time }` } className="Category-row">


### PR DESCRIPTION
Repro step:
1) Choose a random thread in homepage
2) Press the page drop down option
3) Instead of clicking a page number, click any area OTHER THAN the drop down option
4) It will navigate to the first page of the thread

Expected result:
It should destroy the drop down option

I think it is a bug on semantic-ui-react. The drop down option automatically chooses the first item if the user clicks somwhere else. I did a little hack to check if the user clicks the drop down options or not by checking Array.isArray(e._dispatchInstances)