### PR TITLE
[Request] Add faster page action menu

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -125,7 +125,7 @@ class App extends Component {
         <header>
           <div>
             <div className="App-headerLeft">
-              <a href="#" onClick={ toggleDrawer } style={{ textDecoration: 'none' }}>
+              <a id="openDrawerButton" href="#" onClick={ toggleDrawer } style={{ textDecoration: 'none' }}>
                 <Icon name="content" size="large"/>
               </a>
               <a href="#" onClick={ toggleSettings } style={{ textDecoration: 'none' }}>

--- a/src/Thread/Thread.css
+++ b/src/Thread/Thread.css
@@ -134,6 +134,12 @@
   position: fixed;
   z-index: 100;
   width: 200px;
+
+  user-select: none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -o-user-select: none;
 }
 
 .Thread-helper .Thread-buttons-btn{

--- a/src/Thread/Thread.css
+++ b/src/Thread/Thread.css
@@ -118,3 +118,22 @@
   border-bottom: 0;
   top: 4px;
 }
+
+.Thread-helper{
+  position: fixed;
+  z-index: 100;
+  width: 200px;
+}
+
+.Thread-helper .Thread-buttons-btn{
+  background: #eee;
+  line-height: 48px;
+}
+
+.Thread-helper .Thread-helper-close-btn{
+  border-radius: 50%;
+}
+
+.Thread-helper-row{
+  margin-bottom: 1em;
+}

--- a/src/Thread/Thread.js
+++ b/src/Thread/Thread.js
@@ -211,7 +211,7 @@ class Thread extends React.PureComponent {
             <Icon name="star" size="large" id="bookmarkButton" onClick={ bookmark } style={ this.props.app.bookmarks[this.props.params.id] ? { color: '#FBC02D' } : {} }/>
             <Icon name="share alternate" size="large" onClick={ openShareModal }/>
           </div>
-          <Dropdown inline scrolling text={`第 ${ page } 頁`} options={ pagesOptions } onChange={ handlePageChange } value={ page } selectOnBlur={ false }/>
+          <Dropdown inline scrolling text={`第 ${ page } 頁`} id="pageSelect" options={ pagesOptions } onChange={ handlePageChange } value={ page } selectOnBlur={ false }/>
         </div>
       )
       const buttons = (top, bottom) => (
@@ -403,8 +403,8 @@ class Thread extends React.PureComponent {
     }
     const preparePageActionMenu = (e) => {
       if (!this.state.isShowHelper){
-        var x = e.clientX;
-        var y = e.clientY;
+        var x = e.clientX || e.touches[0].clientX;
+        var y = e.clientY || e.touches[0].clientY;
         // Check for a long click
         timer = setTimeout(() => {
           showPageActionMenuAt(x, y);
@@ -456,10 +456,10 @@ class Thread extends React.PureComponent {
     const handleModalClose = () => this.setState({ shareText: null })
 
     return (
-      <div onMouseDown={ preparePageActionMenu } onMouseUp={ cancelPageActionMenu } onContextMenu={ cancelPageActionMenu } onMouseMove={ cancelPageActionMenu }>
+      <div onMouseDown={ preparePageActionMenu } onMouseUp={ cancelPageActionMenu } onContextMenu={ cancelPageActionMenu } onMouseMove={ cancelPageActionMenu } onTouchCancel={ cancelPageActionMenu } onTouchEnd={ cancelPageActionMenu } onTouchMove={ cancelPageActionMenu } onTouchStart={ preparePageActionMenu }>
         <div className="Thread-helper" hidden={ !this.state.isShowHelper } style={ getPageActionMenuPosition() } ref="actionMenuHelper">
           <div className="Thread-helper-row">
-            <div className="Thread-buttons-btn" onClick={ pageActionBack }>返回</div>
+            <div className="Thread-buttons-btn" onClick={ pageActionBack }>BW</div>
             <div className="Thread-buttons-btn" onClick={ pageActionGoTop }>最頂</div>
             <div className="Thread-buttons-btn" onClick={ pageActionBookmark }>留名</div>
           </div>

--- a/src/Thread/Thread.js
+++ b/src/Thread/Thread.js
@@ -438,7 +438,7 @@ class Thread extends React.PureComponent {
     const handleModalClose = () => this.setState({ shareText: null })
 
     return (
-      <div onMouseDown={ preparePageActionMenu } onMouseUp={ cancelPageActionMenu } onContextMenu={ cancelPageActionMenu }>
+      <div onMouseDown={ preparePageActionMenu } onMouseUp={ cancelPageActionMenu } onContextMenu={ cancelPageActionMenu } onMouseMove={ cancelPageActionMenu }>
         <div className="Thread-helper" hidden={ !this.state.isShowHelper } style={ getPageActionMenuPosition() } ref="actionMenuHelper">
           <div className="Thread-helper-row">
             <div className="Thread-buttons-btn" onClick={ pageActionBack }>返回</div>


### PR DESCRIPTION
**Usage**
1. Click-and-hold at any position.
2. An action menu helper will come out according to current mouse location. (This function not available on mobile device)

**Preview**
<img width="272" alt="screen shot 2016-12-06 at 5 21 16 am" src="https://cloud.githubusercontent.com/assets/16607137/20902830/dab001a2-bb73-11e6-9f5f-67bf121d6f2a.png">
